### PR TITLE
Fail more gracefully and do not block build

### DIFF
--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -174,13 +174,6 @@ def process_coverity_nodes(app, doctree, fromdocname):
         # Create failed topnode
         for node in doctree.traverse(CoverityDefect):
             top_node = create_top_node("Failed to connect to Coverity Server")
-            table = nodes.table()
-            tgroup = nodes.tgroup()
-            tbody = nodes.tbody()
-
-            tgroup += tbody
-            table += tgroup
-            top_node += table
             node.replace_self(top_node)
         return
 


### PR DESCRIPTION
When there is no connection or wrong data build is terminated. This
seems like a wrong behavior as the plugin actually blocks any sphinx
build if its blocks cannot be resolved. To fix this the whole try-except
block is wrapped around connection items, which makes build just display
the error, but still continue.

Tested with setting PC offline and building example documentation.