### PR TITLE
More generic exception catching, e.g. Unauthorized is also caught

### DIFF
--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -170,7 +170,7 @@ def process_coverity_nodes(app, doctree, fromdocname):
         report_info(env, 'done')
         coverity_service = CoverityDefectService(coverity_conf_service)
         coverity_service.login(app.config.coverity_credentials['username'], app.config.coverity_credentials['password'])
-    except URLError:
+    except Exception:
         # Create failed topnode
         for node in doctree.traverse(CoverityDefect):
             top_node = create_top_node("Failed to connect to Coverity Server")


### PR DESCRIPTION
When user didn't provide his login details and he doesn't want to use
the plugin in his documentation build, the previous version stopped as a
Exception('Unauthorized') message came. Catching this, just gives a
warning and lets the user pass with the remaining of his documents.