### PR TITLE
The try-except clause needs to stretch out a bit

### DIFF
--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -205,7 +205,7 @@ def process_coverity_nodes(app, doctree, fromdocname):
                                                    checker=node['checker'], impact=node['impact'], kind=node['kind'],
                                                    classification=node['classification'], action=node['action'],
                                                    component=node['component'], cwe=node['cwe'], cid=node['cid'])
-        except URLError as e:
+        except (URLError, AttributeError) as e:
             report_warning(env, 'failed with %s' % e)
             continue
         report_info(env, "%d received" % (defects['totalNumberOfRecords']))


### PR DESCRIPTION
This covers error when there are no snapshots in stream or some other attribute errors in obtaining the defects from coverty_service.