### PR TITLE
Provide error text outside of the table

### DIFF
--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -248,13 +248,12 @@ def process_coverity_nodes(app, doctree, fromdocname):
 
                 tbody += row
             report_info(env, "done")
+            top_node += table
         except AttributeError as e:
             report_info(env, 'No issues matching your query or empty stream. %s' % e)
-            row = nodes.row()
-            row += create_cell('No issues matching your query or empty stream')
-            tbody += row
+            top_node += table
+            top_node += nodes.paragraph(text='No issues matching your query or empty stream')
 
-        top_node += table
         node.replace_self(top_node)
 #        try:
 #            percentage = int(100 * count_covered / count_total)


### PR DESCRIPTION
There was an issue with Latex rendering when we reported the error, but
did not complete table row with empty number of remaining columns.
Current solution closes the table (header displayed only) and provides
the normal paragraph of text below the table.

html renderer had no problems with previous implementation, but it is
nice to have a decent pdf rendering.