### PR TITLE
Fail more gracefully when password or user name are not entered

### DIFF
--- a/mlx/coverity_services.py
+++ b/mlx/coverity_services.py
@@ -149,6 +149,7 @@ class CoverityConfigurationService(Service):
         super(CoverityConfigurationService, self).__init__(transport, hostname, port, ws_version)
         self.checkers = None
         url = self.get_ws_url('configurationservice')
+        logging.getLogger('suds.client').setLevel(logging.CRITICAL)
         try:
             self.client = Client(url)
             logging.info("Validated presence of Coverity Configuration Service [%s]", url)


### PR DESCRIPTION
Before we threw and exception but #13 told us we need to fail more
gracefully and not stop the build. This now does not stop the build, but
prints the fail exception.

I have increased the level of Suds logger (fixed increase) so now Errors are not polluting UI with suds messages (very useful with debugging, but I don't think end users will like it).