### PR TITLE
Login to server once, retrieve defects with each node

### DIFF
--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -180,7 +180,8 @@ class SphinxCoverityConnector():
             self.project_name = coverity_conf_service.get_project_name(stream)
             report_info(env, 'done')
             self.coverity_service = CoverityDefectService(coverity_conf_service)
-            self.coverity_service.login(app.config.coverity_credentials['username'], app.config.coverity_credentials['password'])
+            self.coverity_service.login(app.config.coverity_credentials['username'],
+                                        app.config.coverity_credentials['password'])
         except (URLError, HTTPError, Exception, ValueError) as error_info:
             self.coverity_login_error_msg = error_info
             report_info(env, 'failed with: %s' % error_info)
@@ -228,10 +229,10 @@ class SphinxCoverityConnector():
             # Get items from server
             report_info(env, 'obtaining defects... ', True)
             try:
-                defects = self.coverity_service.get_defects(self.project_name, app.config.coverity_credentials['stream'],
-                                                       checker=node['checker'], impact=node['impact'], kind=node['kind'],
-                                                       classification=node['classification'], action=node['action'],
-                                                       component=node['component'], cwe=node['cwe'], cid=node['cid'])
+                defects = self.coverity_service.get_defects(self.project_name, app.config.coverity_credentials['stream'],   # noqa: E501
+                                                            checker=node['checker'], impact=node['impact'], kind=node['kind'],  # noqa: E501
+                                                            classification=node['classification'], action=node['action'],   # noqa: E501
+                                                            component=node['component'], cwe=node['cwe'], cid=node['cid'])  # noqa: E501
             except (URLError, AttributeError, Exception) as e:
                 report_warning(env, 'failed with %s' % e, fromdocname)
                 continue
@@ -248,7 +249,7 @@ class SphinxCoverityConnector():
                             # CID is default and even if it is in disregard
                             row += create_cell(str(defect['cid']),
                                                url=self.coverity_service.get_defect_url(app.config.coverity_credentials['stream'],  # noqa: E501
-                                                                                   str(defect['cid'])))
+                                                                                        str(defect['cid'])))
                         elif 'Category' == item_col:
                             row += create_cell(defect['displayCategory'])
                         elif 'Impact' == item_col:
@@ -350,7 +351,6 @@ def cov_attribute_value_to_col(defect, name):
     return col
 
 
-
 # Extension setup
 def setup(app):
     '''Extension setup'''
@@ -369,7 +369,7 @@ def setup(app):
 
     app.add_node(CoverityDefect)
 
-    sphinx_coverity_connector =  SphinxCoverityConnector()
+    sphinx_coverity_connector = SphinxCoverityConnector()
 
     app.add_directive('coverity-list', CoverityDefectListDirective)
 


### PR DESCRIPTION
We were logging in and retrieving stream and project information from
coverity server with each node. This is not needed and is now done when
builder initializes. It also enabled us to print nicer warning outputs
when there was a login error, but we still do not fail build with it. It
is up for external tools (mlx.warnings) to error in case warnings are
unwanted. It also means that in case you have plugin in `conf.py`,
but you don't use it (no directives), it will not print errors or fail your builds.

When bad login credentials are provided:
```
Running Sphinx v1.8.3
Login to Coverity server... failed with: (401, 'Unauthorized')
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 1 added, 0 changed, 0 removed
reading sources... [100%] index                                                                                                                                                                             
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index                                                                                                                                                                              
sphinx-coverity-extension/example/index.rst: WARNING: Connection failed: (401, 'Unauthorized')
generating indices... genindex
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 1 warning.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.
```

When stream is wrong:
```
Running Sphinx v1.8.3
Login to Coverity server... done
obtaining stream information... failed with: No such Coverity stream [fail] found on [http://coverity.melexis.com:8080]
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 1 added, 0 changed, 0 removed
reading sources... [100%] index                                                                                                                                                                             
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index                                                                                                                                                                              
sphinx-coverity-extension/example/index.rst: WARNING: Connection failed: No such Coverity stream [fail] found on [http://coverity.urlname]
generating indices... genindex
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 1 warning.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.
```

I only moved `initialize_environment` and `process_coverity_nodes` into common class `SphinxCoverityConnector` which makes sure that coverty_service and project_name variables are shared. Because of that I also was able to move error handling (initialized in init), which now prints login failed information at node position in document (so in case there are no nodes and plugin fails, we also do not get any warnings).

Fixes #12

Fixes #16 
