### PR TITLE
Add reference to traceability items in Comment column

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,7 +204,7 @@ To run tests and checks we use tox.
     # to run tests
     tox
 
-To build example locally you will need to install some dependencies and set your enviornment
+To build example locally you will need to install some dependencies and set your environment
 
 .. code-block:: bash
 

--- a/example/conf.py
+++ b/example/conf.py
@@ -35,7 +35,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.graphviz',
     'mlx.traceability',
-    'coverity',
+    'mlx.coverity',
     'sphinx_selective_exclude.eager_only',
     'sphinx_selective_exclude.modindex_exclude',
     'sphinx_selective_exclude.search_auto_exclude'
@@ -190,13 +190,15 @@ html_context = {
 
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+'papersize': 'a4paper',
 
 # The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-#'preamble': '',
+'preamble': 
+r'\setcounter{tocdepth}{3}'
+r'\usepackage{pdflscape}',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/example/conf.py
+++ b/example/conf.py
@@ -13,6 +13,7 @@
 
 import sys, os
 import mlx.coverity
+import mlx.traceability
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -33,6 +34,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.graphviz',
+    'mlx.traceability',
     'coverity',
     'sphinx_selective_exclude.eager_only',
     'sphinx_selective_exclude.modindex_exclude',

--- a/example/conf.py
+++ b/example/conf.py
@@ -318,4 +318,3 @@ coverity_credentials = {
 }
 
 TRACEABILITY_ITEM_ID_REGEX = r"([A-Z_]+-[A-Z0-9_]+)"
-URL_REGEX = r"(http[s]?://[\S]*)"

--- a/example/conf.py
+++ b/example/conf.py
@@ -317,3 +317,4 @@ coverity_credentials = {
     'stream': config('COVERITY_STREAM'),
 }
 
+TRACEABILITY_ITEM_ID_REGEX = "([A-Z_]+-[A-Z0-9_]+)"

--- a/example/conf.py
+++ b/example/conf.py
@@ -317,4 +317,5 @@ coverity_credentials = {
     'stream': config('COVERITY_STREAM'),
 }
 
-TRACEABILITY_ITEM_ID_REGEX = "([A-Z_]+-[A-Z0-9_]+)"
+TRACEABILITY_ITEM_ID_REGEX = r"([A-Z_]+-[A-Z0-9_]+)"
+URL_REGEX = r"(http[s]?://[\S]*)"

--- a/example/deviate.rst
+++ b/example/deviate.rst
@@ -1,0 +1,11 @@
+Coverity deviation description
+==============================
+
+Below items from mlx.traceability plugin are used to describe deviations for certain groups of items.
+
+.. item:: DEVIATE-MISRA_UNUSED_EXAMPLE Deviate this example
+
+    This is s test for deviation item description which explains rationale behind group of errors triagged as
+    intentional in Coverity.
+
+

--- a/example/deviate.rst
+++ b/example/deviate.rst
@@ -5,7 +5,7 @@ Coverity deviation description
 
 Below items from mlx.traceability plugin are used to describe deviations for certain groups of items.
 
-.. item:: DEVIATE-MISRA_UNUSED_EXAMPLE Deviate this example
+.. item:: STATIC_DEVIATE-MISRA_UNUSED_EXAMPLE Deviate this example
 
     This is s test for deviation item description which explains rationale behind group of errors triagged as
     intentional in Coverity.

--- a/example/deviate.rst
+++ b/example/deviate.rst
@@ -1,3 +1,5 @@
+.. _deviate:
+
 Coverity deviation description
 ==============================
 

--- a/example/index.rst
+++ b/example/index.rst
@@ -11,6 +11,8 @@ Contents:
 .. toctree::
     :maxdepth: 1
 
+    deviate
+
 Summary
 -------
 

--- a/example/index.rst
+++ b/example/index.rst
@@ -3,6 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+:orphan:
+
 Welcome to Sphinx Coverity extension example's documentation!
 =============================================================
 
@@ -10,6 +12,8 @@ Contents:
 
 .. toctree::
     :maxdepth: 1
+    :glob:
+    :caption: Example documentation index
 
     deviate
 
@@ -23,11 +27,18 @@ filters on classification.
 
 Coverity plugin table
 
+.. role:: latex(raw)
+    :format: latex
+
+:latex:`\begin{landscape}`
+
+.. tabularcolumns:: |p{1cm}|p{2.8cm}|p{4cm}|p{9cm}|
+
 .. coverity-list:: Coverity defects table
-    :col: CID,Classification,Action,Comment
+    :col: CID,Classification,Checker,Comment
     :widths: 10, 15, 15, 60
     :chart: Intentional,Bug,Pending+Unclassified
-    :classification: Bug
+    :classification: Intentional,Bug,Pending,Unclassified
     :checker: MISRA
 
 .. coverity-list:: Coverity defects table
@@ -39,6 +50,8 @@ Coverity plugin chart generation
 
 .. coverity-list:: Coverity defects chart
     :chart: Intentional,Pending+Unclassified
+
+:latex:`\end{landscape}`
 
 This text is not part of any item
 

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -7,19 +7,22 @@ Sphinx extension for restructured text that adds Coverity reporting to documenta
 See README.rst for more details.
 '''
 from __future__ import print_function
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-import pkg_resources
-from re import findall
 
 from hashlib import sha256
 from os import environ, mkdir, path
-from urlextract import URLExtract
+from re import findall
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import pkg_resources
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from mlx.coverity_services import CoverityConfigurationService, CoverityDefectService
 from sphinx import __version__ as sphinx_version
 from sphinx.environment import NoUri
+from urlextract import URLExtract
+
+from mlx.coverity_services import CoverityConfigurationService, CoverityDefectService
+
 try:
     # For Python 3.0 and later
     from urllib.error import URLError, HTTPError

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -405,7 +405,6 @@ def cov_attribute_value_to_col(defect, name):
     return col
 
 
-
 def make_internal_item_ref(app, fromdocname, item_id):
     """
     Creates and returns a reference node for an item or returns None when the item cannot be found in the traceability

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -301,6 +301,7 @@ class SphinxCoverityConnector():
                                     ref_node = make_internal_item_ref(app, fromdocname, item_id)
                                     if ref_node:
                                         text.replace(item_id, str(ref_node))
+                                        col = create_cell(text)
                                 row += col
                             elif 'Classification' == item_col:
                                 row += cov_attribute_value_to_col(defect, 'Classification')

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -314,8 +314,8 @@ class SphinxCoverityConnector():
                             elif 'Component' == item_col:
                                 row += create_cell(defect['componentName'])
                             elif 'Comment' == item_col:
-                                text = cov_attribute_value_to_col(defect, 'Comment').children[0].children[0]
-                                contents = create_paragraph_with_links(app, fromdocname, text)
+                                text = str(cov_attribute_value_to_col(defect, 'Comment').children[0].children[0])
+                                contents = create_paragraph_with_links(text, app, fromdocname)
                                 row += nodes.entry('', contents)
                             elif 'Classification' == item_col:
                                 row += cov_attribute_value_to_col(defect, 'Classification')

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -474,7 +474,7 @@ def link_to_urls(contents, text, *args):
         remaining_text = remaining_text.replace(text_before + url, '', 1)
 
     if remaining_text:
-        contents.append(nodes.Text(remaining_text))
+        link_to_item_ids(contents, text, *args)
 
 
 def link_to_item_ids(contents, text, app, docname):
@@ -484,7 +484,6 @@ def link_to_item_ids(contents, text, app, docname):
         text_before = remaining_text.split(item)[0]
         if text_before:
             contents.append(nodes.Text(text_before))
-
         ref_node = make_internal_item_ref(app, docname, item)
         if ref_node is None:  # no link could be made
             ref_node = nodes.Text(item)
@@ -493,7 +492,7 @@ def link_to_item_ids(contents, text, app, docname):
         remaining_text = remaining_text.replace(text_before + item, '', 1)
 
     if remaining_text:
-        contents.append(nodes.Text(remaining_text))
+        contents.append(nodes.Text(remaining_text))  # no URL or item ID in this text
 
 
 def make_internal_item_ref(app, fromdocname, item_id):

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -12,8 +12,6 @@ from hashlib import sha256
 from os import environ, mkdir, path
 from re import findall
 
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 import pkg_resources
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -22,6 +20,10 @@ from sphinx.environment import NoUri
 from urlextract import URLExtract
 
 from mlx.coverity_services import CoverityConfigurationService, CoverityDefectService
+import matplotlib as mpl
+if not environ.get('DISPLAY'):
+    mpl.use('Agg')
+import matplotlib.pyplot as plt  # noqa: E731
 
 try:
     # For Python 3.0 and later
@@ -31,9 +33,6 @@ except ImportError:
     from urllib2 import URLError, HTTPError
 if sphinx_version >= '1.6.0':
     from sphinx.util.logging import getLogger
-
-if not environ.get('DISPLAY'):
-    mpl.use('Agg')
 
 
 def report_warning(env, msg, docname, lineno=None):
@@ -513,7 +512,7 @@ def make_internal_item_ref(app, fromdocname, item_id):
 
     item_info = env.traceability_collection.get_item(item_id)
     if not item_info:
-        report_warning(env, "Could not find item ID '%s' in traceability collection.", fromdocname)
+        report_warning(env, "Could not find item ID '%s' in traceability collection." % item_id, fromdocname)
         return None
 
     ref_node = nodes.reference('', '')

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -18,14 +18,13 @@ from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from mlx.coverity_services import CoverityConfigurationService, CoverityDefectService
 from sphinx import __version__ as sphinx_version
+from sphinx.environment import NoUri
 try:
     # For Python 3.0 and later
     from urllib.error import URLError, HTTPError
 except ImportError:
     # Fall back to Python 2's urllib2
     from urllib2 import URLError, HTTPError
-from sphinx.environment import NoUri
-from sphinx import __version__ as sphinx_version
 if sphinx_version >= '1.6.0':
     from sphinx.util.logging import getLogger
 

--- a/mlx/coverity_services.py
+++ b/mlx/coverity_services.py
@@ -3,9 +3,9 @@
 '''Services and other utilities for Coverity scripting'''
 
 # General
-import re
 import csv
 import logging
+import re
 try:
     # For Python 3.0 and later
     from urllib.error import URLError

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ project_url = 'https://github.com/melexis/sphinx-coverity-extension'
 if sys.version_info[0] == 2:
     requires = ['Sphinx>=0.6', 'docutils', 'suds', 'setuptools_scm']
 else:
-    requires = ['Sphinx>=0.6', 'docutils', 'suds-py3', 'setuptools_scm', 'matplotlib']
+    requires = ['Sphinx>=0.6', 'docutils', 'suds-py3', 'setuptools_scm', 'matplotlib', 'urlextract']
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ import sys
 project_url = 'https://github.com/melexis/sphinx-coverity-extension'
 
 if sys.version_info[0] == 2:
-    requires = ['Sphinx>=0.6', 'docutils', 'suds', 'setuptools_scm', 'matplotlib', 'urlextract-py2.7']
+    requires = ['Sphinx>=0.6', 'docutils', 'suds', 'setuptools_scm', 'matplotlib==3.0.3', 'urlextract-py2.7']
 else:
-    requires = ['Sphinx>=0.6', 'docutils', 'suds-py3', 'setuptools_scm', 'matplotlib', 'urlextract']
+    requires = ['Sphinx>=0.6', 'docutils', 'suds-py3', 'setuptools_scm', 'matplotlib==3.0.3', 'urlextract']
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 project_url = 'https://github.com/melexis/sphinx-coverity-extension'
 
 if sys.version_info[0] == 2:
-    requires = ['Sphinx>=0.6', 'docutils', 'suds', 'setuptools_scm']
+    requires = ['Sphinx>=0.6', 'docutils', 'suds', 'setuptools_scm', 'matplotlib', 'urlextract-py2.7']
 else:
     requires = ['Sphinx>=0.6', 'docutils', 'suds-py3', 'setuptools_scm', 'matplotlib', 'urlextract']
 
@@ -36,6 +36,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Documentation',
         'Topic :: Documentation :: Sphinx',
         'Topic :: Utilities',

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ import sys
 project_url = 'https://github.com/melexis/sphinx-coverity-extension'
 
 if sys.version_info[0] == 2:
-    requires = ['Sphinx>=0.6', 'docutils', 'suds', 'setuptools_scm', 'matplotlib==3.0.3', 'urlextract-py2.7']
+    requires = ['Sphinx>=0.6', 'docutils', 'suds', 'setuptools_scm', 'matplotlib<=3.0.3', 'urlextract-py2.7']
 else:
-    requires = ['Sphinx>=0.6', 'docutils', 'suds-py3', 'setuptools_scm', 'matplotlib==3.0.3', 'urlextract']
+    requires = ['Sphinx>=0.6', 'docutils', 'suds-py3', 'setuptools_scm', 'matplotlib<=3.0.3', 'urlextract']
 
 
 setup(

--- a/tests/test_coverity.py
+++ b/tests/test_coverity.py
@@ -16,7 +16,7 @@ from lxml import objectify
 
 class TestCoverity(TestCase):
 
-    def SetUp(self):
+    def setUp(self):
         ''' SetUp to be run before each test to provide clean working env '''
 
     @patch('mlx.coverity_services.UsernameToken')
@@ -114,4 +114,3 @@ class TestCoverity(TestCase):
 
         suds_client_mock.side_effect = Exception((401, 'Unauthorized'))
         coverity_conf_service.login('', '')
-

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps=
     py37: suds-py3
     setuptools_scm
     matplotlib
+    urlextract
     mlx.warnings >= 0.1.2
     lxml
     sphinx1.3: sphinx <= 1.3.9999

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps=
     py27: urlextract-py2.7
     py37: urlextract
     setuptools_scm
-    matplotlib
+    matplotlib==3.0.3
     mlx.warnings >= 0.1.2
     lxml
     sphinx1.3: sphinx <= 1.3.9999
@@ -46,7 +46,7 @@ whitelist_externals =
     mlx-warnings
 commands=
     test: {posargs:py.test --cov=mlx.coverity --cov-report=term-missing -vv tests/}
-    sphinx: make -C doc html
+    sphinx: make -C example html
 
 [testenv:py27-check]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,10 @@ deps=
     python-decouple
     py27: suds
     py37: suds-py3
+    py27: urlextract-py2.7
+    py37: urlextract
     setuptools_scm
     matplotlib
-    urlextract
     mlx.warnings >= 0.1.2
     lxml
     sphinx1.3: sphinx <= 1.3.9999

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps=
     py27: urlextract-py2.7
     py37: urlextract
     setuptools_scm
-    matplotlib==3.0.3
+    matplotlib <= 3.0.3
     mlx.warnings >= 0.1.2
     lxml
     sphinx1.3: sphinx <= 1.3.9999


### PR DESCRIPTION
The tool reports a warning when a `traceability_collection` exists in the build environment and the item ID could not be found inside it.

Resolves issue #27.