### PR TITLE
Advanced chart

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,11 +135,23 @@ filtering classification items with value `Bug`, you should use the following sn
 
     .. coverity-list:: Custom table title
         :col: CID,Classification,Action,Comment
+        :widths: 10 20 20 50
         :classification: Bug
-        :width: 10,20,20,50
 
 The plugin will then automatically replace this block with the table queried from the Coverity server.
 
+You can also call this block `.. coverity-list:` to generate a pie chart. For example, to label the amount of items
+classified as Intentional and the amount of items classified as Pending or Unclassified, while filtering classification
+items, you should use the following snippet:
+
+.. code-block:: python
+
+    .. coverity-list:: Custom chart title
+        :chart: classification:Intentional,Pending+Unclassified
+        :classification: Bug,Intentional,Pending,Unclassified
+
+The plugin allows the use of both display options, `col`and `chart`, at the same time as well. In that case, they share
+all filtering options.
 
 Attributes to coverity-list
 ===========================
@@ -193,9 +205,19 @@ work for this attribute, e.g. `MISRA`.
 chart
 -----
 
-This optional, second display option will draw a pie chart that visualizes the amount of results for each specified
-classification option. The parameters can be a list of classification options, comma-separated, or even
-plus-sign-separated to combine multiple options into the same slice.
+This optional, second display option will draw a pie chart that visualizes the amount of results for each allowed
+`<<attribute>>` option. Firstly, the attribute can be specified, followed by a colon. The default attribute is
+`classification`. Secondly, you have two optoins. Either you specify a list of attribue values, comma-separated or even
+plus-sign-separated for a merge into the same slice or else you define the minimum number of defects with the same
+attribute value that needs to be reached for them to be grouped together into a slice. All other defects get labeled as
+Other. For example, to visualize the most prevalent MISRA rules with a grouping threshhold of 50 items, you should use
+the following code snippet:
+
+.. code-block:: python
+
+    .. coverity-list:: Chart of most prevalent MISRA rules
+        :chart: checker:50
+        :checker: MISRA
 
 -------------
 Contributions

--- a/README.rst
+++ b/README.rst
@@ -206,11 +206,11 @@ chart
 -----
 
 This optional, second display option will draw a pie chart that visualizes the amount of results for each allowed
-`<<attribute>>` option. Firstly, the attribute can be specified, followed by a colon. The default attribute is
+`<<attribute>>` option. Firstly, the attribute can be specified, followed by a colon `:`. The default attribute is
 `classification`. Secondly, you have two optoins. Either you specify a list of attribue values, comma-separated or even
-plus-sign-separated for a merge into the same slice or else you define the minimum number of defects with the same
+plus-sign-separated for a merge into the same slice, or else you define the minimum threshold of defects with the same
 attribute value that needs to be reached for them to be grouped together into a slice. All other defects get labeled as
-Other. For example, to visualize the most prevalent MISRA violations with a grouping threshhold of 50 items, you should
+Other. For example, to visualize the most prevalent MISRA violations with a grouping threshold of 50 items, you should
 use the following code snippet:
 
 .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -210,12 +210,12 @@ This optional, second display option will draw a pie chart that visualizes the a
 `classification`. Secondly, you have two optoins. Either you specify a list of attribue values, comma-separated or even
 plus-sign-separated for a merge into the same slice or else you define the minimum number of defects with the same
 attribute value that needs to be reached for them to be grouped together into a slice. All other defects get labeled as
-Other. For example, to visualize the most prevalent MISRA rules with a grouping threshhold of 50 items, you should use
-the following code snippet:
+Other. For example, to visualize the most prevalent MISRA violations with a grouping threshhold of 50 items, you should
+use the following code snippet:
 
 .. code-block:: python
 
-    .. coverity-list:: Chart of most prevalent MISRA rules
+    .. coverity-list:: Chart of the most prevalent MISRA violations
         :chart: checker:50
         :checker: MISRA
 

--- a/example/index.rst
+++ b/example/index.rst
@@ -37,7 +37,7 @@ Coverity plugin table
 .. coverity-list:: Coverity defects table
     :col: CID,Classification,Checker,Comment
     :widths: 10, 15, 15, 60
-    :chart: Intentional,Bug,Pending+Unclassified
+    :chart: checker:50
     :classification: Intentional,Bug,Pending,Unclassified
     :checker: MISRA
 

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -396,6 +396,7 @@ class SphinxCoverityConnector():
                 labels = list(chart_labels.keys())
                 sizes = list(chart_labels.values())
                 fig, axes = plt.subplots()
+                fig.set_size_inches(10, 6)
                 axes.pie(sizes, labels=labels, autopct=pct_wrapper(sizes), startangle=90)
                 axes.axis('equal')
                 folder_name = path.join(env.app.srcdir, '_images')


### PR DESCRIPTION
Make `:chart:` option more advanced:

- Allow a colon-separated `<<attribute>>` parameter.
- Add an alternative to a list of attribute values: a threshold value for grouping defects with the same attribute value if their amount reaches the threshold value.

Fix typos in `:widths:` option in example code snippet.

Fix cut off labels in pie chart image when labels are too long by increasing pie chart width from 8 to 10.