### PR TITLE
Fix example for latexpdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 build/
 dist/
 example/_build
+example/_images
 tests/docs/basic/_build
 tests/docs/autodoc/docs/_build
 .tox/

--- a/README.rst
+++ b/README.rst
@@ -182,7 +182,7 @@ widths
 
 Optional attribute that provides possibility to set each column width to a predefined percentage. This makes it nicer
 for the pdf builders that are able to fit the table to the printable page width and, because of longtable, also provide
-nice table continuation through multiple pages. Its parameters must be space-separated.
+nice table continuation through multiple pages. Its parameters must be a space-separated list of integers.
 
 classification
 --------------

--- a/example/deviate.rst
+++ b/example/deviate.rst
@@ -7,7 +7,7 @@ Below items from mlx.traceability plugin are used to describe deviations for cer
 
 .. item:: STATIC_DEVIATE-MISRA_UNUSED_EXAMPLE Deviate this example
 
-    This is s test for deviation item description which explains rationale behind group of errors triagged as
+    This is a test for deviation item description which explains rationale behind group of errors triaged as
     intentional in Coverity.
 
 

--- a/example/index.rst
+++ b/example/index.rst
@@ -5,6 +5,8 @@
 
 :orphan:
 
+.. _index:
+
 Welcome to Sphinx Coverity extension example's documentation!
 =============================================================
 
@@ -32,24 +34,24 @@ Coverity plugin table
 
 :latex:`\begin{landscape}`
 
-.. tabularcolumns:: |p{1cm}|p{2.8cm}|p{4cm}|p{9cm}|
-
-.. coverity-list:: Coverity defects table
+.. coverity-list:: Coverity defects table and chart
     :col: CID,Classification,Checker,Comment
-    :widths: 10, 15, 15, 60
-    :chart: checker:50
+    :widths: 2 4 6 10
+    :chart: checker:1
     :classification: Intentional,Bug,Pending,Unclassified
     :checker: MISRA
 
+Every MISRA rule gets labeled separately.
+
 .. coverity-list:: Coverity defects table
     :col: CID,Checker,Status,Comment
-    :widths: 10, 15, 15, 60
-    :classification: Pending,Unclassified
-
-Coverity plugin chart generation
+    :widths: 21 60 35 120
 
 .. coverity-list:: Coverity defects chart
     :chart: Intentional,Pending+Unclassified
+    :classification: Bug,Intentional,Pending,Unclassified
+
+Coverity plugin chart only generation.
 
 :latex:`\end{landscape}`
 

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -396,7 +396,7 @@ class SphinxCoverityConnector():
                 labels = list(chart_labels.keys())
                 sizes = list(chart_labels.values())
                 fig, axes = plt.subplots()
-                fig.set_size_inches(10, 6)
+                fig.set_size_inches(7, 4)
                 axes.pie(sizes, labels=labels, autopct=pct_wrapper(sizes), startangle=90)
                 axes.axis('equal')
                 folder_name = path.join(env.app.srcdir, '_images')


### PR DESCRIPTION
Removed `tabularcolumns` and clarified the use of the `widths` options.
Reduced the size of the pie chart from 10x6 to 7x4 inches.