### PR TITLE
Fix filter attributes

### DIFF
--- a/mlx/coverity_services.py
+++ b/mlx/coverity_services.py
@@ -402,7 +402,7 @@ class CoverityDefectService(Service):
             name (str): String representation of the attribute.
         """
         logging.info('Using %s filter [%s]', name, attribute)
-        validated = self.config_service.add_filter_rqt(name, attribute, args, kwargs)
+        validated = self.config_service.add_filter_rqt(name, attribute, *args, **kwargs)
         logging.info('Resolves to [%s]', validated)
         if validated:
             self.filters += ("<%s(%s)> " % (name, validated))


### PR DESCRIPTION
`args` and `kwargs` were passed incorrectly to the next function which resulted in filter attributes not being applied. This fixes the problem.