### PR TITLE
Refactor get_defects by replacing most of its kwargs

### DIFF
--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -93,7 +93,8 @@ class CoverityDefect(nodes.General, nodes.Element):
         'action': None,
         'component': None,
         'cwe': None,
-        'cid': None,}
+        'cid': None,
+    }
 
 
 # -----------------------------------------------------------------------------

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -85,6 +85,15 @@ def pct_wrapper(sizes):
 # Declare new node types (based on others):
 class CoverityDefect(nodes.General, nodes.Element):
     '''Coverity defect'''
+    filters = {
+        'checker': None,
+        'impact': None,
+        'kind': None,
+        'classification': None,
+        'action': None,
+        'component': None,
+        'cwe': None,
+        'cid': None,}
 
 
 # -----------------------------------------------------------------------------
@@ -157,31 +166,34 @@ class CoverityDefectListDirective(Directive):
 
         # Process ``chart`` option
         if 'chart' in self.options:
-            if ':' in self.options['chart']:
-                item_list_node['chart_attribute'] = self.options['chart'].split(':')[0].capitalize()
-            else:
-                item_list_node['chart_attribute'] = 'Classification'
-
-            parameters = self.options['chart'].split(':')[-1]  # str
-            item_list_node['chart'] = parameters.split(',')  # list
-            # try to convert parameters to int, in case a min slice size is defined instead of filter options
-            try:
-                item_list_node['min_slice_size'] = int(item_list_node['chart'][0])
-                item_list_node['chart'] = []  # only when a min slice size is defined
-            except ValueError:
-                item_list_node['min_slice_size'] = 1
+            self._process_chart_option(item_list_node)
         else:
             item_list_node['chart'] = ''
 
         # Process the optional filters
-        filters = ['checker', 'impact', 'kind', 'classification', 'action', 'component', 'cwe', 'cid']
-        for fil in filters:
-            if fil in self.options:
-                item_list_node[fil] = self.options[fil]
-            else:
-                item_list_node[fil] = None
-
+        item_list_node.filters = {k: (self.options[k] if k in self.options else v)
+                                  for (k, v) in item_list_node.filters.items()}
         return [item_list_node]
+
+    def _process_chart_option(self, node):
+        """ Processes the `chart` option.
+
+        Args:
+            node (CoverityDefect): CoverityDefect object used to store this directive's options and their parameters.
+        """
+        if ':' in self.options['chart']:
+            node['chart_attribute'] = self.options['chart'].split(':')[0].capitalize()
+        else:
+            node['chart_attribute'] = 'Classification'
+
+        parameters = self.options['chart'].split(':')[-1]  # str
+        node['chart'] = parameters.split(',')  # list
+        # try to convert parameters to int, in case a min slice size is defined instead of filter options
+        try:
+            node['min_slice_size'] = int(node['chart'][0])
+            node['chart'] = []  # only when a min slice size is defined
+        except ValueError:
+            node['min_slice_size'] = 1
 
 
 class SphinxCoverityConnector():
@@ -402,10 +414,7 @@ class SphinxCoverityConnector():
             (suds.sudsobject.mergedDefectsPageDataObj) Suds mergedDefectsPageDataObj object containing filtered defects.
         """
         report_info(env, 'obtaining defects... ', True)
-        defects = self.coverity_service.get_defects(self.project_name, self.stream, checker=node['checker'],
-                                                    impact=node['impact'], kind=node['kind'],
-                                                    classification=node['classification'], action=node['action'],
-                                                    component=node['component'], cwe=node['cwe'], cid=node['cid'])
+        defects = self.coverity_service.get_defects(self.project_name, self.stream, node.filters)
         report_info(env, "%d received" % (defects['totalNumberOfRecords']))
         report_info(env, "building defects table and/or chart... ", True)
         return defects

--- a/mlx/coverity_services.py
+++ b/mlx/coverity_services.py
@@ -13,7 +13,7 @@ except ImportError:
     # Fall back to Python 2's urllib2
     from urllib2 import URLError
 
-# For Coverity: SOAP
+# For Coverity - SOAP
 from suds.client import Client
 from suds.wsse import Security, UsernameToken
 
@@ -163,10 +163,10 @@ class CoverityConfigurationService(Service):
         super(CoverityConfigurationService, self).login(username, password)
         version = self.get_version()
         if version is None:
-            raise RuntimeError("Authentication to [%s] FAILED for [%s] account: check password"
+            raise RuntimeError("Authentication to [%s] FAILED for [%s] account - check password"
                                % (self.get_service_url(), username))
         else:
-            logging.info("Authentication to [%s] using [%s] account was OK: version [%s]",
+            logging.info("Authentication to [%s] using [%s] account was OK - version [%s]",
                          self.get_service_url(), username, version.externalVersion)
 
     def get_version(self):
@@ -214,7 +214,7 @@ class CoverityConfigurationService(Service):
 
     @staticmethod
     def get_snapshot_id(snapshots, idx=1):
-        '''Get the nth snapshot (base 1): minus numbers to count from the end backwards (-1 = last)'''
+        '''Get the nth snapshot (base 1) - minus numbers to count from the end backwards (-1 = last)'''
         if bool(idx):
             num_snapshots = len(snapshots)
             if idx < 0:
@@ -224,7 +224,7 @@ class CoverityConfigurationService(Service):
 
             if abs(required) > 0 and abs(required) <= num_snapshots:
                 # base zero
-                return snapshots[required: 1].id
+                return snapshots[required - 1].id
         return 0
 
     def get_snapshot_detail(self, snapshot_id):
@@ -444,7 +444,7 @@ class CoverityDefectService(Service):
                 filter_map.attributeValueIds.append(attribute_value_id)
 
     def get_defect(self, cid, stream):
-        '''Get the details pertaining a specific CID: it may not have defect instance details if newly eliminated
+        '''Get the details pertaining a specific CID - it may not have defect instance details if newly eliminated
         (fixed)'''
         logging.info('Fetching data for CID [%s] in stream [%s] ...', cid, stream)
 
@@ -497,7 +497,7 @@ class CoverityDefectService(Service):
             attr_value = ext_ref_id
             comment_value = 'Automatically recorded reference to new JIRA ticket.'
         else:
-            # set to a space: which works as a blank without the WS complaining :-)
+            # set to a space - which works as a blank without the WS complaining :-)
             attr_value = " "
             comment_value = 'Automatically cleared former JIRA ticket reference.'
 
@@ -554,7 +554,7 @@ class CoverityDefectService(Service):
                     logging.info('Found [%s] = [%s]',
                                  attr_value.attributeDefinitionId.name, attr_value.attributeValueId.name)
                     return True, attr_value.attributeValueId.name
-                # break attribute name search: either no value or it doesn't match
+                # break attribute name search - either no value or it doesn't match
                 break
         logging.warning('Event for attribute [%s] not found', name)
         return False, None

--- a/mlx/coverity_services.py
+++ b/mlx/coverity_services.py
@@ -13,7 +13,7 @@ except ImportError:
     # Fall back to Python 2's urllib2
     from urllib2 import URLError
 
-# For Coverity - SOAP
+# For Coverity: SOAP
 from suds.client import Client
 from suds.wsse import Security, UsernameToken
 
@@ -163,10 +163,10 @@ class CoverityConfigurationService(Service):
         super(CoverityConfigurationService, self).login(username, password)
         version = self.get_version()
         if version is None:
-            raise RuntimeError("Authentication to [%s] FAILED for [%s] account - check password"
+            raise RuntimeError("Authentication to [%s] FAILED for [%s] account: check password"
                                % (self.get_service_url(), username))
         else:
-            logging.info("Authentication to [%s] using [%s] account was OK - version [%s]",
+            logging.info("Authentication to [%s] using [%s] account was OK: version [%s]",
                          self.get_service_url(), username, version.externalVersion)
 
     def get_version(self):
@@ -214,7 +214,7 @@ class CoverityConfigurationService(Service):
 
     @staticmethod
     def get_snapshot_id(snapshots, idx=1):
-        '''Get the nth snapshot (base 1) - minus numbers to count from the end backwards (-1 = last)'''
+        '''Get the nth snapshot (base 1): minus numbers to count from the end backwards (-1 = last)'''
         if bool(idx):
             num_snapshots = len(snapshots)
             if idx < 0:
@@ -224,7 +224,7 @@ class CoverityConfigurationService(Service):
 
             if abs(required) > 0 and abs(required) <= num_snapshots:
                 # base zero
-                return snapshots[required - 1].id
+                return snapshots[required: 1].id
         return 0
 
     def get_snapshot_detail(self, snapshot_id):
@@ -288,15 +288,17 @@ class CoverityDefectService(Service):
             raise
 
     def get_defects(self, project, stream, filters, custom=None):
-        '''
-        Get a list of defects for given stream, with some query criteria
+        """ Gets a list of defects for given stream, with some query criteria.
 
-        Arguments:
-        project (str) - Name of the project to query
-        stream (str) - Name of the stream to query
-        filters (dict) - Dictionary with attribute names as keys and CSV lists of attribute values to query as values
-        custom (str) - A custom query
-        '''
+        Args:
+            project (str): Name of the project to query
+            stream (str): Name of the stream to query
+            filters (dict): Dictionary with attribute names as keys and CSV lists of attribute values to query as values
+            custom (str): A custom query
+
+        Returns:
+            (suds.sudsobject.mergedDefectsPageDataObj) Suds mergedDefectsPageDataObj object containing filtered defects
+        """
         logging.info('Querying Coverity for defects in project [%s] stream [%s] ...', project, stream)
 
         # define the project
@@ -442,7 +444,7 @@ class CoverityDefectService(Service):
                 filter_map.attributeValueIds.append(attribute_value_id)
 
     def get_defect(self, cid, stream):
-        '''Get the details pertaining a specific CID - it may not have defect instance details if newly eliminated
+        '''Get the details pertaining a specific CID: it may not have defect instance details if newly eliminated
         (fixed)'''
         logging.info('Fetching data for CID [%s] in stream [%s] ...', cid, stream)
 
@@ -480,7 +482,7 @@ class CoverityDefectService(Service):
     # update the external reference id to a third party
     def update_ext_reference_attribute(self, cid, triage_store, ext_ref_id, ccomment=None):
         '''Update external reference attribute for given CID'''
-        logging.info('Updating Coverity - CID [%s] in TS [%s] with Ext Ref [%s]', cid, triage_store, ext_ref_id)
+        logging.info('Updating Coverity: CID [%s] in TS [%s] with Ext Ref [%s]', cid, triage_store, ext_ref_id)
 
         # triage store identifier
         triage_store_id = self.client.factory.create('triageStoreIdDataObj')
@@ -495,7 +497,7 @@ class CoverityDefectService(Service):
             attr_value = ext_ref_id
             comment_value = 'Automatically recorded reference to new JIRA ticket.'
         else:
-            # set to a space - which works as a blank without the WS complaining :-)
+            # set to a space: which works as a blank without the WS complaining :-)
             attr_value = " "
             comment_value = 'Automatically cleared former JIRA ticket reference.'
 
@@ -552,7 +554,7 @@ class CoverityDefectService(Service):
                     logging.info('Found [%s] = [%s]',
                                  attr_value.attributeDefinitionId.name, attr_value.attributeValueId.name)
                     return True, attr_value.attributeValueId.name
-                # break attribute name search - either no value or it doesn't match
+                # break attribute name search: either no value or it doesn't match
                 break
         logging.warning('Event for attribute [%s] not found', name)
         return False, None

--- a/tests/test_coverity.py
+++ b/tests/test_coverity.py
@@ -94,7 +94,17 @@ class TestCoverity(TestCase):
         suds_security_mock.assert_called_once()
         suds_username_mock.assert_called_once_with('user', 'password')
 
-        coverity_service.get_defects('projectname', 'somestream')
+        filters = {
+            'checker': None,
+            'impact': None,
+            'kind': None,
+            'classification': None,
+            'action': None,
+            'component': None,
+            'cwe': None,
+            'cid': None,
+        }
+        coverity_service.get_defects('projectname', 'somestream', filters)
 
     @patch('mlx.coverity_services.UsernameToken')
     @patch('mlx.coverity_services.Security')


### PR DESCRIPTION
MR #39 did not end up in the master branch yet.

Refactor functions inside `CoverityDefectListDirective`.
Add dictionary `filters` attribute to `CoverityDefect` to  replace kwargs in `get_defects` function.
Reverted unintentional changes from #39.