### PR TITLE
Fix KeyError while preparing pie chart

### DIFF
--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -461,7 +461,7 @@ class SphinxCoverityConnector():
             defect (suds.sudsobject.mergedDefectDataObj): Defect object from suds.
         """
         if node['chart_attribute'].upper() in self.column_map.keys():
-            attribute_value = str(defect[self.column_map[node['chart_attribute']]])
+            attribute_value = str(defect[self.column_map[node['chart_attribute'].upper()]])
         else:
             col = cov_attribute_value_to_col(defect, node['chart_attribute'])
             attribute_value = str(col.children[0].children[0])  # get text in paragraph of column


### PR DESCRIPTION
In #38 the use of `column_map` was introduced. It has column names in upper cases as key values. I forgot to use `upper()` somewhere which caused a `KeyError`. This fixes it.