### PR TITLE
Only use the sonar-python complexity check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,8 +10,7 @@ checks:
     config:
       threshold: 500
   method-complexity:
-    config:
-      threshold: 8
+    enabled: false
   method-count:
     config:
       threshold: 20


### PR DESCRIPTION
Only use the sonar-python complexity check by removing the code climate complexity check. Its default threshold value is strict enough.