### PR TITLE
Ask for username and/or password if undefined as env variable

### DIFF
--- a/example/index.rst
+++ b/example/index.rst
@@ -10,8 +10,6 @@
 Welcome to Sphinx Coverity extension example's documentation!
 =============================================================
 
-Contents:
-
 .. toctree::
     :maxdepth: 1
     :glob:

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -58,7 +58,7 @@ class SphinxCoverityConnector():
         try:
             if not app.config.coverity_credentials['username']:
                 if version_info.major < 3:
-                    get_input = raw_input  # pylint: disable=undefined-variable
+                    get_input = raw_input  # noqa, pylint: disable=undefined-variable
                 else:
                     get_input = input
                 app.config.coverity_credentials['username'] = get_input("Coverity username: ")

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -56,14 +56,7 @@ class SphinxCoverityConnector():
 
         # Login to Coverity and obtain stream information
         try:
-            if not app.config.coverity_credentials['username']:
-                if version_info.major < 3:
-                    get_input = raw_input  # noqa, pylint: disable=undefined-variable
-                else:
-                    get_input = input
-                app.config.coverity_credentials['username'] = get_input("Coverity username: ")
-            if not app.config.coverity_credentials['password']:
-                app.config.coverity_credentials['password'] = getpass("Coverity password: ")
+            self.input_credentials(app.config.coverity_credentials)
             report_info(env, 'Login to Coverity server... ', True)
             coverity_conf_service = CoverityConfigurationService(app.config.coverity_credentials['transport'],
                                                                  app.config.coverity_credentials['hostname'],
@@ -87,7 +80,10 @@ class SphinxCoverityConnector():
             self.coverity_service.login(app.config.coverity_credentials['username'],
                                         app.config.coverity_credentials['password'])
         except (URLError, HTTPError, Exception, ValueError) as error_info:  # pylint: disable=broad-except
-            self.coverity_login_error_msg = error_info
+            if isinstance(error_info, EOFError):
+                self.coverity_login_error_msg = "Coverity credentials are not configured."
+            else:
+                self.coverity_login_error_msg = str(error_info)
             report_info(env, 'failed with: %s' % error_info)
             self.coverity_login_error = True
 
@@ -123,6 +119,22 @@ class SphinxCoverityConnector():
 
     # -----------------------------------------------------------------------------
     # Helper functions of event handlers
+    @staticmethod
+    def input_credentials(config_credentials):
+        """ Ask user to input username and/or password if they haven't been configured yet.
+
+        Args:
+            config_credentials (dict): Dictionary to store the user's credentials.
+        """
+        if not config_credentials['username']:
+            if version_info.major < 3:
+                get_input = raw_input  # noqa, pylint: disable=undefined-variable
+            else:
+                get_input = input
+            config_credentials['username'] = get_input("Coverity username: ")
+        if not config_credentials['password']:
+            config_credentials['password'] = getpass("Coverity password: ")
+
     def get_filtered_defects(self, node, env):
         """ Fetch defects from suds using filters stored in the given CoverityDefect object.
 

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -7,6 +7,7 @@ Sphinx extension for restructured text that adds Coverity reporting to documenta
 See README.rst for more details.
 '''
 from __future__ import print_function
+from getpass import getpass
 
 import pkg_resources
 
@@ -54,6 +55,10 @@ class SphinxCoverityConnector():
 
         # Login to Coverity and obtain stream information
         try:
+            if not app.config.coverity_credentials['username']:
+                app.config.coverity_credentials['username'] = input("Coverity username: ")
+            if not app.config.coverity_credentials['password']:
+                app.config.coverity_credentials['password'] = getpass("Coverity password: ")
             report_info(env, 'Login to Coverity server... ', True)
             coverity_conf_service = CoverityConfigurationService(app.config.coverity_credentials['transport'],
                                                                  app.config.coverity_credentials['hostname'],

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -8,6 +8,7 @@ See README.rst for more details.
 '''
 from __future__ import print_function
 from getpass import getpass
+from sys import version_info
 
 import pkg_resources
 
@@ -56,7 +57,11 @@ class SphinxCoverityConnector():
         # Login to Coverity and obtain stream information
         try:
             if not app.config.coverity_credentials['username']:
-                app.config.coverity_credentials['username'] = input("Coverity username: ")
+                if version_info.major < 3:
+                    get_input = raw_input  # pylint: disable=undefined-variable
+                else:
+                    get_input = input
+                app.config.coverity_credentials['username'] = get_input("Coverity username: ")
             if not app.config.coverity_credentials['password']:
                 app.config.coverity_credentials['password'] = getpass("Coverity password: ")
             report_info(env, 'Login to Coverity server... ', True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ norecursedirs= .tox
 
 [flake8]
 exclude = .git,*conf.py,build,dist,tests/docs
-builtins="raw_input"
 max-line-length = 120
 per-file-ignores =
     mlx/coverity.py:E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ norecursedirs= .tox
 
 [flake8]
 exclude = .git,*conf.py,build,dist,tests/docs
+builtins="raw_input"
 max-line-length = 120
 per-file-ignores =
     mlx/coverity.py:E402


### PR DESCRIPTION
Closes #48 
When building in a docker container and credentials are missing, the build won't be halted, but a warning will be printed that clarifies that credentials haven't been configured.

Also removed "Contents: " string from index.rst since LaTeX created a new page for it after the TOC page. The :caption: option of the toc directive should be sufficient.