### PR TITLE
Include _static folder from mlx.traceability plugin in example

### DIFF
--- a/example/conf.py
+++ b/example/conf.py
@@ -138,7 +138,7 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-#html_static_path = [os.path.join(os.path.dirname(mlx.traceability.__file__), 'assets')]
+html_static_path.append(os.path.join(os.path.dirname(mlx.traceability.__file__), 'assets'))
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
The mlx.traceability executes a JavaScript script to strip away the CSS properties of the hyperlink html element of a traceability item. This script is now included in example/conf.py.