### PR TITLE
Fix filters not working in pdf build

### DIFF
--- a/example/index.rst
+++ b/example/index.rst
@@ -51,7 +51,7 @@ Every MISRA rule gets labeled separately.
 
 .. coverity-list:: Unclassified coverity defects
     :col: CID,Classification,Action
-    :widths: 2 4 6 10
+    :widths: 2 4 6
     :classification: Unclassified
 
 .. coverity-list:: Coverity defects chart

--- a/example/index.rst
+++ b/example/index.rst
@@ -49,6 +49,11 @@ Every MISRA rule gets labeled separately.
     :col: CID,Location,Reference
     :widths: 21 95 120
 
+.. coverity-list:: Unclassified coverity defects
+    :col: CID,Classification,Action
+    :widths: 2 4 6 10
+    :classification: Unclassified
+
 .. coverity-list:: Coverity defects chart
     :chart: Intentional,Pending+Unclassified
     :classification: Bug,Intentional,Pending,Unclassified

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -130,7 +130,7 @@ class SphinxCoverityConnector():
             (suds.sudsobject.mergedDefectsPageDataObj) Suds mergedDefectsPageDataObj object containing filtered defects.
         """
         report_info('obtaining defects... ', True)
-        defects = self.coverity_service.get_defects(self.project_name, self.stream, node.filters)
+        defects = self.coverity_service.get_defects(self.project_name, self.stream, node['filters'])
         report_info("%d received" % (defects['totalNumberOfRecords']))
         report_info("building defects table and/or chart... ", True)
         return defects

--- a/mlx/coverity_directives/coverity_defect_list.py
+++ b/mlx/coverity_directives/coverity_defect_list.py
@@ -343,8 +343,8 @@ class CoverityDefectListDirective(Directive):
             item_list_node['chart'] = ''
 
         # Process the optional filters
-        item_list_node.filters = {k: (self.options[k] if k in self.options else v)
-                                  for (k, v) in item_list_node.filters.items()}
+        item_list_node['filters'] = {k: (self.options[k] if k in self.options else v)
+                                     for (k, v) in item_list_node.filters.items()}
         return [item_list_node]
 
     def _process_chart_option(self, node):


### PR DESCRIPTION
It seems that it's unsafe to store any processed directive information as an attribute of the docutils node. The solution is to store the dictionary holding the filter attributes as `node['filters']` instead of `node.filters`.

Resolves #54 