### PR TITLE
Tweak version format as used in Sphinx error logs

### DIFF
--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -164,6 +164,6 @@ def setup(app):
     app.connect('builder-inited', sphinx_coverity_connector.initialize_environment)
 
     try:
-        return {'version': '%(prog)s {version}'.format(version=pkg_resources.require('mlx.coverity')[0].version)}
+        return {'version': pkg_resources.require('mlx.coverity')[0].version}
     except LookupError:
         return {'version': 'dev'}


### PR DESCRIPTION
In the Sphinx error log we get the following information for this plugin:

`mlx.coverity (%(prog)s 0.2.2) from /usr/local/lib/python3.7/dist-packages/mlx/coverity.py`

This PR aims to change it to be in line with how the other plugins display their version nr, which would look like this:

`mlx.coverity (0.2.2) from /usr/local/lib/python3.7/dist-packages/mlx/coverity.py`