### PR TITLE
Provide ability to re-link the TRACEABILITY_ITEM_ID

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,20 @@ feature.
 
     TRACEABILITY_ITEM_ID_REGEX = r"([A-Z_]+-[A-Z0-9_]+)"
 
+Alter links to traceability items
+=================================
+
+If the item ID matched by *TRACEABILITY_ITEM_ID_REGEX* is incorrect, e.g. it does not exist in the collection of
+traceability items, you can configure the plugin to link to the desired item ID instead.
+Add the item ID returned by Coverity as a key to the Python dictionary *TRACEABILITY_ITEM_ID_REGEX* and the desired
+item ID as value.
+
+.. code-block:: python
+
+    TRACEABILITY_ITEM_RELINK = {
+        "STATIC_DEVIATE-MISRA_RULE_1_0": "STATIC_DEVIATE-MISRA_1_0",
+    }
+
 Default config
 ==============
 
@@ -132,6 +146,7 @@ The plugin itself holds a default config that can be used for any Coverity proje
     }
 
     TRACEABILITY_ITEM_ID_REGEX = r"([A-Z_]+-[A-Z0-9_]+)"
+    TRACEABILITY_ITEM_RELINK = {}
 
 This default configuration, which is built into the plugin, can be overridden through the *conf.py* of your project.
 

--- a/example/conf.py
+++ b/example/conf.py
@@ -320,3 +320,4 @@ coverity_credentials = {
 }
 
 TRACEABILITY_ITEM_ID_REGEX = r"([A-Z_]+-[A-Z0-9_]+)"
+TRACEABILITY_ITEM_RELINK = {}

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -152,6 +152,7 @@ def setup(app):
                          'env')
 
     app.add_config_value('TRACEABILITY_ITEM_ID_REGEX', r"([A-Z_]+-[A-Z0-9_]+)", 'env')
+    app.add_config_value('TRACEABILITY_ITEM_RELINK', {}, 'env')
 
     app.add_node(CoverityDefect)
 

--- a/mlx/coverity_item_element.py
+++ b/mlx/coverity_item_element.py
@@ -150,12 +150,14 @@ def link_to_item_ids(contents, text, cid, app, docname):
         text_before = remaining_text.split(item)[0]
         if text_before:
             contents.append(nodes.Text(text_before))
+        remaining_text = remaining_text.replace(text_before + item, '', 1)
+
+        if item in app.config.TRACEABILITY_ITEM_RELINK:
+            item = app.config.TRACEABILITY_ITEM_RELINK[item]
         ref_node = make_internal_item_ref(app, docname, item, cid)
         if ref_node is None:  # no link could be made
             ref_node = nodes.Text(item)
         contents.append(ref_node)
-
-        remaining_text = remaining_text.replace(text_before + item, '', 1)
 
     if remaining_text:
         contents.append(nodes.Text(remaining_text))  # no URL or item ID in this text


### PR DESCRIPTION
If the item ID matched by *TRACEABILITY_ITEM_ID_REGEX* is incorrect, e.g. it does not exist in the collection of
traceability items, you can configure the plugin to link to the desired item ID instead.
Add the item ID returned by Coverity as a key to the Python dictionary *TRACEABILITY_ITEM_ID_REGEX* and the desired
item ID as value. Example:

```
  TRACEABILITY_ITEM_RELINK = {
      "STATIC_DEVIATE-MISRA_RULE_1_0": "STATIC_DEVIATE-MISRA_1_0",
  }
```

Closes #62 