### PR TITLE
Declare parallel read and write

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -165,14 +165,11 @@ def setup(app):
     app.connect('builder-inited', sphinx_coverity_connector.initialize_environment)
 
     try:
-        return {
-                'version': pkg_resources.require('mlx.coverity')[0].version,
-                'parallel_read_safe': True,
-                'parallel_write_safe': True,
-        }
+        version = pkg_resources.require('mlx.coverity')[0].version
     except LookupError:
-        return {
-                'version': 'dev',
-                'parallel_read_safe': True,
-                'parallel_write_safe': True,
-        }
+        version = 'dev'
+    return {
+        'version': version,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/mlx/coverity.py
+++ b/mlx/coverity.py
@@ -165,6 +165,14 @@ def setup(app):
     app.connect('builder-inited', sphinx_coverity_connector.initialize_environment)
 
     try:
-        return {'version': pkg_resources.require('mlx.coverity')[0].version}
+        return {
+                'version': pkg_resources.require('mlx.coverity')[0].version,
+                'parallel_read_safe': True,
+                'parallel_write_safe': True,
+        }
     except LookupError:
-        return {'version': 'dev'}
+        return {
+                'version': 'dev',
+                'parallel_read_safe': True,
+                'parallel_write_safe': True,
+        }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requires = ['Sphinx>=2.1', 'docutils', 'setuptools_scm', 'matplotlib', 'mlx.trac
 
 setup(
     name='mlx.coverity',
-    setup_requires=['setuptools_scm'],
+    setup_requires=['setuptools-scm>=6.0.0,<7.*'],
     use_scm_version=True,
     url=project_url,
     license='GNU General Public License v3 (GPLv3)',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author_email='cmo@melexis.com',
     description='Sphinx coverity extension from Melexis',
     long_description=open("README.rst").read(),
+    long_description_content_type='text/x-rst',
     zip_safe=False,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tox.ini
+++ b/tox.ini
@@ -57,13 +57,15 @@ commands=
 [testenv:check]
 deps =
     docutils
+    twine
     check-manifest
     flake8
     readme-renderer
     pygments
 skip_install = true
 commands =
-    python setup.py check --strict --metadata --restructuredtext
+    python setup.py sdist
+    twine check dist/*
     check-manifest {toxinidir} -u
     flake8 --ignore=W605,W391 mlx tests setup.py
 


### PR DESCRIPTION
Since the new sphinx, we need to declare if extension is able to do parallel read and parallel write. Since each directive is its own bundle we can do parallel reads and writes for each call easily. It might crash the Coverity Connect server, but that is not extension problem atm :wink: