### PR TITLE
Update actions due to deprecation warning

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -37,13 +37,13 @@ jobs:
       run: tox -e coverage
     - name: Codecov uploader
       if: matrix.python-version == 3.9
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
     - name: Static checks
       if: matrix.python-version == 3.9
       run: tox -e check
     - name: Upload HTML documentation
       if: matrix.python-version == 3.9
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: html-doc
         path: example/_build/html
@@ -54,21 +54,21 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download HTML documentation from job 'test'
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: html-doc
         path: example/_build/html
     - name: Disable jekyll
       run: touch example/_build/html/.nojekyll
     - name: Deploy documentation
-      uses: JamesIves/github-pages-deploy-action@4.1.3
+      uses: JamesIves/github-pages-deploy-action@4.4.1
       with:
         branch: gh-pages
         folder: example/_build/html
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/sphinx-coverity-extension'
 
-requires = ['Sphinx>=2.1', 'docutils', 'setuptools_scm', 'matplotlib', 'mlx.traceability', 'suds-py3',
+requires = ['Sphinx>=2.1,<7.0', 'docutils', 'setuptools_scm', 'matplotlib', 'mlx.traceability', 'suds-py3',
             'urlextract']
 
 
 setup(
     name='mlx.coverity',
-    setup_requires=['setuptools-scm>=6.0.0,<7.*'],
+    setup_requires=['setuptools-scm>=6.0.0,<7.0'],
     use_scm_version=True,
     url=project_url,
     license='GNU General Public License v3 (GPLv3)',
@@ -29,7 +29,6 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Some actions use obsoleted nodejs version, so we need to upgrade them. While I was doing, I also upgraded other actions to their latest versions.