### PR TITLE
Fix CI job for releases

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,7 @@ jobs:
       run: tox -e check
     - name: Upload HTML documentation
       if: matrix.python-version == 3.9
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: html-doc
         path: example/_build/html
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download HTML documentation from job 'test'
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: html-doc
         path: example/_build/html


### PR DESCRIPTION
CI of release 2.0.0 failed, likely due to version mismatch between `actions/upload-artifact` and `actions/download-artifact`. https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md#which-versions-of-the-artifacts-packages-are-compatible